### PR TITLE
Add Copilot model configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ A VS Code extension that leverages GitHub Copilot to provide code reviews for An
 - **Two review modes**  
   - **Review Angular Code** – uses `angular_code_review_guidelines.md`  
   - **Review Jest Unit Tests** – uses `jest_unit_test_code_review_guidelines.md`  
-- **Custom guidelines**  
-  Point to your own `CODE_REVIEW_GUIDELINES.md` via a workspace setting; otherwise falls back to the built-in defaults.  
-- **Context-menu integration**  
-  Right-click inside the editor when you have a selection to choose your review mode.  
+- **Custom guidelines**
+  Point to your own `CODE_REVIEW_GUIDELINES.md` via a workspace setting; otherwise falls back to the built-in defaults.
+- **Model selection**
+  Choose which Copilot model to use via the `codeReviewer.model` setting (defaults to `GPT-4o`).
+- **Context-menu integration**
+  Right-click inside the editor when you have a selection to choose your review mode.
 - **Command-palette support**  
   Run either review command directly from the palette.
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
           "default": "",
           "description": "Absolute or workspace-relative path to a custom guidelines file. Leave blank to use the built-in default."
         }
+        ,
+        "codeReviewer.model": {
+          "type": "string",
+          "default": "GPT-4o",
+          "description": "Copilot model to use when generating the review prompts."
+        }
       }
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ async function runReview(
   // Load user-specified guidelines if provided
   const config = vscode.workspace.getConfiguration('codeReviewer');
   let customPath = config.get<string>('guidelinesPath') || '';
+  const model = config.get<string>('model') || 'GPT-4o';
   let guidelines = '';
 
   if (customPath) {
@@ -41,6 +42,8 @@ async function runReview(
   }
 
   const prompt = [
+    `/model ${model}`,
+    '',
     `Please review the following code:`,
     '',
     selectedText,


### PR DESCRIPTION
## Summary
- allow selecting a custom Copilot model with `codeReviewer.model` (default `GPT-4o`)
- insert `/model` command when sending prompts
- document new setting

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_684bb6c095dc8327b97d8e0593f770c7